### PR TITLE
Add HCOPE gate evaluation and CI tests

### DIFF
--- a/.github/workflows/hcope-evaluation.yml
+++ b/.github/workflows/hcope-evaluation.yml
@@ -1,0 +1,21 @@
+name: HCOPE Evaluation CI
+
+on: [push, pull_request]
+
+jobs:
+  test-hcope:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run HCOPE gate tests
+        run: |
+          pytest tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q

--- a/hcope.py
+++ b/hcope.py
@@ -1,0 +1,62 @@
+"""High-Confidence Off-Policy Evaluation (HCOPE) utilities.
+
+This module provides helpers to compute a lower confidence bound (LCB)
+for policy performance metrics and a gate function that checks whether a
+policy meets a minimum expected performance threshold before live
+execution.
+"""
+from __future__ import annotations
+
+from scipy.stats import norm
+
+
+def calculate_lcb(estimated_metric: float, estimated_std: float, confidence_level: float = 0.95) -> float:
+    """Calculate the lower confidence bound for an estimated metric.
+
+    Args:
+        estimated_metric: Estimated value of the metric (e.g. Sharpe ratio).
+        estimated_std: Standard deviation of the metric estimate.
+        confidence_level: Confidence level for the bound (default 95%).
+
+    Returns:
+        The lower confidence bound of the metric.
+    """
+    z_score = norm.ppf(confidence_level)
+    return estimated_metric - z_score * estimated_std
+
+
+def evaluate_policy_performance(
+    estimated_sharpe: float, estimated_std_sharpe: float, confidence_level: float = 0.95
+) -> float:
+    """Evaluate policy performance using the lower confidence bound of Sharpe ratio.
+
+    Args:
+        estimated_sharpe: Estimated Sharpe ratio of the policy.
+        estimated_std_sharpe: Standard deviation of the Sharpe ratio estimate.
+        confidence_level: Confidence level for the bound (default 95%).
+
+    Returns:
+        The lower confidence bound of the Sharpe ratio.
+    """
+    return calculate_lcb(estimated_sharpe, estimated_std_sharpe, confidence_level)
+
+
+def hcope_gate(
+    sharpe_ratio: float, sharpe_std: float, threshold: float = 1.0, confidence_level: float = 0.95
+) -> bool:
+    """Check if a policy passes the HCOPE gate.
+
+    The gate passes when the lower confidence bound of the Sharpe ratio is
+    greater than or equal to the provided threshold.
+
+    Args:
+        sharpe_ratio: Estimated Sharpe ratio of the policy.
+        sharpe_std: Standard deviation of the Sharpe ratio estimate.
+        threshold: Minimum acceptable lower confidence bound.
+        confidence_level: Confidence level for the bound (default 95%).
+
+    Returns:
+        ``True`` if the policy passes the gate, ``False`` otherwise.
+    """
+    lcb_sharpe = evaluate_policy_performance(sharpe_ratio, sharpe_std, confidence_level)
+    return lcb_sharpe >= threshold

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+pytest

--- a/tests/test_hcope_gate.py
+++ b/tests/test_hcope_gate.py
@@ -1,0 +1,9 @@
+from hcope import hcope_gate
+
+
+def test_lcb_pass():
+    assert hcope_gate(1.5, 0.2)
+
+
+def test_lcb_fail():
+    assert not hcope_gate(1.2, 0.4)


### PR DESCRIPTION
## Summary
- add utilities to compute lower confidence bound (LCB) for policy Sharpe ratio
- introduce HCOPE gate function and unit tests for pass/fail scenarios
- configure GitHub Actions workflow to run HCOPE gate tests

## Testing
- `pytest tests/test_hcope_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b72cc3798832ca95df3c63a6fefe6