### PR TITLE
Add informative messaging to HCOPE gate and tests

### DIFF
--- a/hcope.py
+++ b/hcope.py
@@ -56,7 +56,17 @@ def hcope_gate(
         confidence_level: Confidence level for the bound (default 95%).
 
     Returns:
-        ``True`` if the policy passes the gate, ``False`` otherwise.
+        ``True`` if the policy passes the gate, ``False`` otherwise. The
+        function also prints a short message indicating whether the policy
+        passed or failed and, in the failure case, the computed LCB.
     """
-    lcb_sharpe = evaluate_policy_performance(sharpe_ratio, sharpe_std, confidence_level)
-    return lcb_sharpe >= threshold
+    lcb_sharpe = evaluate_policy_performance(
+        sharpe_ratio, sharpe_std, confidence_level
+    )
+    if lcb_sharpe >= threshold:
+        print("Policy passed HCOPE gate! Proceeding with execution.")
+        return True
+    print(
+        f"Policy failed HCOPE gate. LCB: {lcb_sharpe} < threshold: {threshold}"
+    )
+    return False

--- a/tests/test_hcope_gate.py
+++ b/tests/test_hcope_gate.py
@@ -1,9 +1,14 @@
 from hcope import hcope_gate
 
 
-def test_lcb_pass():
+def test_lcb_pass(capsys):
     assert hcope_gate(1.5, 0.2)
+    captured = capsys.readouterr().out.strip()
+    assert "Policy passed HCOPE gate" in captured
 
 
-def test_lcb_fail():
+def test_lcb_fail(capsys):
     assert not hcope_gate(1.2, 0.4)
+    captured = capsys.readouterr().out.strip()
+    assert captured.startswith("Policy failed HCOPE gate. LCB:")
+    assert "< threshold: 1.0" in captured


### PR DESCRIPTION
## Summary
- Enhance `hcope_gate` to print pass/fail messages alongside returning the boolean decision
- Extend HCOPE gate tests to assert that the expected console messages are produced

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b92d94e28832ca8e70808d95dbe2f