### PR TITLE
Add HCOPE gate usage example

### DIFF
--- a/examples/hcope_gate_example.py
+++ b/examples/hcope_gate_example.py
@@ -1,0 +1,19 @@
+"""Example demonstrating use of the HCOPE gate.
+
+This script shows how to evaluate whether a policy should move to live
+execution based on its estimated Sharpe ratio and uncertainty.  The
+``hcope_gate`` function computes a lower confidence bound on the Sharpe
+ratio and compares it to a threshold.  If the gate passes, the policy is
+considered safe to deploy.
+"""
+from hcope import hcope_gate
+
+# Estimated Sharpe ratio and its standard deviation
+estimated_sharpe = 1.2
+estimated_std_sharpe = 0.5
+
+if hcope_gate(estimated_sharpe, estimated_std_sharpe):
+    print("Running live deployment...")
+else:
+    print("Adjusting policy strategy...")
+


### PR DESCRIPTION
## Summary
- Add illustrative script demonstrating how to evaluate policy performance using the HCOPE gate

## Testing
- `pytest -q`
- `pytest tests/test_hcope_gate.py tests/test_hcope.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b92ee15a8832c94587e033c18526f