### PR TITLE
Relax HCOPE gate threshold to zero

### DIFF
--- a/hcope.py
+++ b/hcope.py
@@ -42,17 +42,21 @@ def evaluate_policy_performance(
 
 
 def hcope_gate(
-    sharpe_ratio: float, sharpe_std: float, threshold: float = 1.0, confidence_level: float = 0.95
+    sharpe_ratio: float,
+    sharpe_std: float,
+    threshold: float = 0.0,
+    confidence_level: float = 0.95,
 ) -> bool:
     """Check if a policy passes the HCOPE gate.
 
-    The gate passes when the lower confidence bound of the Sharpe ratio is
-    greater than or equal to the provided threshold.
+    The gate passes when the lower confidence bound (LCB) of the Sharpe ratio
+    is greater than or equal to the provided threshold.  By default the
+    threshold is set to ``0.0`` which simply checks that the LCB is positive.
 
     Args:
         sharpe_ratio: Estimated Sharpe ratio of the policy.
         sharpe_std: Standard deviation of the Sharpe ratio estimate.
-        threshold: Minimum acceptable lower confidence bound.
+        threshold: Minimum acceptable lower confidence bound (default ``0.0``).
         confidence_level: Confidence level for the bound (default 95%).
 
     Returns:

--- a/tests/test_hcope_gate.py
+++ b/tests/test_hcope_gate.py
@@ -2,8 +2,10 @@ from hcope import hcope_gate
 
 
 def test_lcb_pass():
-    assert hcope_gate(1.5, 0.2)
+    """Gate should pass when the LCB exceeds the default threshold."""
+    assert hcope_gate(1.5, 0.4)
 
 
 def test_lcb_fail():
-    assert not hcope_gate(1.2, 0.4)
+    """Gate should fail when the LCB falls below the default threshold."""
+    assert not hcope_gate(0.8, 0.6)


### PR DESCRIPTION
## Summary
- Set HCOPE gate's default threshold to 0.0 so it only requires positive Sharpe lower bound
- Update HCOPE gate tests for new default threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b936894b8832cadcaa4081eb35588