### PR TITLE
test: expand HCOPE coverage

### DIFF
--- a/.github/workflows/hcope-evaluation.yml
+++ b/.github/workflows/hcope-evaluation.yml
@@ -16,6 +16,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Run HCOPE gate tests
+      - name: Run HCOPE tests
         run: |
-          pytest tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q
+          pytest tests/test_hcope.py tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q

--- a/tests/test_hcope.py
+++ b/tests/test_hcope.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ope.hcope import lower_confidence_bound, evaluate_file
 
 
@@ -13,3 +15,9 @@ def test_evaluate_file_threshold_passes():
     path = "tests/sample_trajectory.json"
     lcb = evaluate_file(path, threshold=0.1)
     assert lcb > 0.1
+
+
+def test_evaluate_file_threshold_fails():
+    path = "tests/sample_trajectory.json"
+    with pytest.raises(SystemExit):
+        evaluate_file(path, threshold=0.5)


### PR DESCRIPTION
## Summary
- add failing-threshold test for hcope's file evaluation
- run HCOPE tests in CI

## Testing
- `pytest tests/test_hcope.py tests/test_hcope_gate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689b93c05648832c8bc0abd680210e1d