### PR TITLE
Update HCOPE CI workflow

### DIFF
--- a/.github/workflows/hcope-evaluation.yml
+++ b/.github/workflows/hcope-evaluation.yml
@@ -6,16 +6,17 @@ jobs:
   test-hcope:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run HCOPE gate tests
-        run: |
-          pytest tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run HCOPE gate tests
+      run: |
+        pytest tests/test_hcope.py --maxfail=1 --disable-warnings -q
+        pytest tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- upgrade HCOPE CI to use latest action versions
- run both HCOPE test suites in the workflow

## Testing
- `pytest tests/test_hcope.py --maxfail=1 --disable-warnings -q`
- `pytest tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9332b41c832cbafea0ed5e50ab2f