### PR TITLE
CI: run HCOPE tests

### DIFF
--- a/.github/workflows/hcope-evaluation.yml
+++ b/.github/workflows/hcope-evaluation.yml
@@ -6,16 +6,20 @@ jobs:
   test-hcope:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run HCOPE gate tests
-        run: |
-          pytest tests/test_hcope_gate.py --maxfail=1 --disable-warnings -q
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run HCOPE gate tests
+      run: |
+        pytest tests/test_hcope.py --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- simplify HCOPE evaluation workflow
- install dependencies with upgraded pip and run tests/test_hcope.py

## Testing
- `pytest tests/test_hcope.py --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9382a600832c90f2296b2fd01e55