### PR TITLE
Provide feedback for HCOPE gate and raise default threshold

### DIFF
--- a/tests/test_hcope_gate.py
+++ b/tests/test_hcope_gate.py
@@ -10,9 +10,9 @@ def test_calculate_lcb_expected_value():
 
 def test_lcb_pass():
     """Gate should pass when the LCB exceeds the default threshold."""
-    assert hcope_gate(1.5, 0.4)
+    assert hcope_gate(3.0, 0.5)
 
 
 def test_lcb_fail():
     """Gate should fail when the LCB falls below the default threshold."""
-    assert not hcope_gate(0.8, 0.6)
+    assert not hcope_gate(1.5, 0.4)


### PR DESCRIPTION
## Summary
- Print Sharpe ratio lower confidence bound during policy evaluation
- Report pass/fail messages in HCOPE gate and require default threshold of 1.0
- Update tests to match the new gate behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba6156fb4832cb47dc4b00729d39a