### PR TITLE
Expose core modules and add placeholders

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,15 @@
+from .execution import arbitrage, directional
+from .exchange import binance, okx
+from .risk import sizer, guards
+from .data import logger, storage
+
+__all__ = [
+    "arbitrage",
+    "directional",
+    "binance",
+    "okx",
+    "sizer",
+    "guards",
+    "logger",
+    "storage",
+]

--- a/core/data/__init__.py
+++ b/core/data/__init__.py
@@ -1,0 +1,3 @@
+from . import logger, storage
+
+__all__ = ["logger", "storage"]

--- a/core/data/logger.py
+++ b/core/data/logger.py
@@ -1,0 +1,5 @@
+"""Project wide logger configuration."""
+import logging
+
+logger = logging.getLogger("omni_arb")
+logger.addHandler(logging.NullHandler())

--- a/core/data/storage.py
+++ b/core/data/storage.py
@@ -1,0 +1,14 @@
+"""Lightweight JSON storage utilities."""
+from pathlib import Path
+from typing import Any
+import json
+
+
+def save(path: str | Path, data: Any) -> None:
+    """Persist data as JSON to *path*."""
+    Path(path).write_text(json.dumps(data))
+
+
+def load(path: str | Path) -> Any:
+    """Load JSON data from *path*."""
+    return json.loads(Path(path).read_text())

--- a/core/exchange/__init__.py
+++ b/core/exchange/__init__.py
@@ -1,0 +1,3 @@
+from . import binance, okx
+
+__all__ = ["binance", "okx"]

--- a/core/exchange/okx.py
+++ b/core/exchange/okx.py
@@ -1,0 +1,37 @@
+"""
+ماژول ارتباط با OKX برای پشتیبانی از حالت Live و Demo.
+"""
+from typing import Any, Dict, Optional
+import os
+import requests
+
+BASE_URL = "https://www.okx.com"
+
+
+def _request(method: str, endpoint: str, *, params: Optional[Dict[str, Any]] = None,
+             data: Optional[Dict[str, Any]] = None, headers: Optional[Dict[str, str]] = None,
+             live: Optional[int] = None) -> Dict[str, Any]:
+    """
+    ارسال درخواست به OKX. در حالت Demo هدر x-simulated-trading: 1 اضافه می‌شود.
+
+    :param method: نوع متد HTTP
+    :param endpoint: مسیر اندپوینت (باید با /api/v5/ شروع شود)
+    :param params: پارامترهای کوئری
+    :param data: بدنه درخواست
+    :param headers: هدرهای اضافی
+    :param live: 1 برای حالت واقعی، 0 برای Demo. در صورت None از متغیر محیطی LIVE استفاده می‌شود.
+    :return: پاسخ به صورت دیکشنری
+    """
+    if live is None:
+        live = int(os.getenv("LIVE", "1"))
+    url = f"{BASE_URL}{endpoint}"
+    headers = headers.copy() if headers else {}
+    if endpoint.startswith("/api/v5/") and not live:
+        headers.setdefault("x-simulated-trading", "1")
+    response = requests.request(method, url, params=params, json=data, headers=headers)
+    return response.json()
+
+
+def place_order(order: Dict[str, Any], live: Optional[int] = None) -> Dict[str, Any]:
+    """ارسال سفارش (v5) به OKX."""
+    return _request("POST", "/api/v5/trade/order", data=order, live=live)

--- a/core/execution/__init__.py
+++ b/core/execution/__init__.py
@@ -1,0 +1,3 @@
+from . import arbitrage, directional
+
+__all__ = ["arbitrage", "directional"]

--- a/core/execution/arbitrage.py
+++ b/core/execution/arbitrage.py
@@ -1,0 +1,7 @@
+"""Arbitrage execution strategy placeholder."""
+from typing import Any, Dict
+
+
+def execute(order: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the order unchanged as a stub implementation."""
+    return order

--- a/core/execution/directional.py
+++ b/core/execution/directional.py
@@ -1,0 +1,7 @@
+"""Directional execution strategy placeholder."""
+from typing import Any, Dict
+
+
+def execute(order: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the order unchanged as a stub implementation."""
+    return order

--- a/core/risk/__init__.py
+++ b/core/risk/__init__.py
@@ -1,0 +1,3 @@
+from . import sizer, guards
+
+__all__ = ["sizer", "guards"]

--- a/core/risk/guards.py
+++ b/core/risk/guards.py
@@ -1,0 +1,29 @@
+"""Utility guard checks for order validation."""
+from typing import Dict
+import yaml
+
+
+def load_risk_config(path: str = "risk.yml") -> Dict[str, float]:
+    """Load risk configuration from a YAML file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def check_latency(latency_ms: float, max_leg_latency_ms: float) -> bool:
+    return latency_ms <= max_leg_latency_ms
+
+
+def check_slippage(slippage_bps: float, max_slippage_bps: float) -> bool:
+    return slippage_bps <= max_slippage_bps
+
+
+def check_depth(depth_notional: float, min_depth_notional: float) -> bool:
+    return depth_notional >= min_depth_notional
+
+
+def check_risk(symbol: str, notional: float, risk_cfg: Dict[str, Dict[str, float]]) -> bool:
+    """Validate notional against risk caps."""
+    max_trade = risk_cfg.get("max_notional_per_trade", float("inf"))
+    per_symbol = risk_cfg.get("per_symbol_caps", {})
+    symbol_cap = per_symbol.get(symbol, float("inf"))
+    return notional <= max_trade and notional <= symbol_cap

--- a/core/risk/sizer.py
+++ b/core/risk/sizer.py
@@ -1,0 +1,9 @@
+"""Simple position sizing utilities."""
+from typing import Union
+
+
+def fixed_fraction(notional: float, fraction: Union[int, float]) -> float:
+    """Calculate position size as a fraction of notional value."""
+    if fraction < 0:
+        raise ValueError("fraction must be non-negative")
+    return notional * float(fraction)


### PR DESCRIPTION
## Summary
- expose execution, exchange, risk, data modules from core
- add placeholder implementations for arbitrage, directional, sizing, logging, storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcd4dc470832cae6bb53c0eed6c94