### PR TITLE
Add httpx dependency for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 pytest
+httpx


### PR DESCRIPTION
## Summary
- include httpx in requirements for test support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcd6e92c0832c84715050cf5638b5